### PR TITLE
Fixed csim and clarvi. Added build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ $ make
 $ ./csim
 ```
 
-The vsim simulator does not currently support memory operations.
+The vsim simulator does not currently support memory operations, which causes runtime errors. To make it execute the following commands:
+```sh
+$ cd vsim
+$ ./runsim.sh
+```
 
 The ecad-labs simulator does not currently have any make instructions.

--- a/README.md
+++ b/README.md
@@ -9,24 +9,29 @@ Versions of RISC-V that only execute the fib() function.
 - ecad-labs: simulator built on SystemVerilog with a more sophisticated core.
 
 ## Build instructions:
-For the java simulator execute the following commands:
+For the java simulator, execute the following commands:
 ```sh
 $ cd jsim
 $ make
 $ make run
 ```
 
-For the C simulator execute the following commands:
+For the C simulator, execute the following commands:
 ```sh
 $ cd csim
 $ make
 $ ./csim
 ```
 
-The vsim simulator does not currently support memory operations, which causes runtime errors. To make it execute the following commands:
+The vsim simulator does not currently support memory operations, which causes runtime errors. To build it, execute the following commands:
 ```sh
 $ cd vsim
 $ ./runsim.sh
 ```
 
-The ecad-labs simulator does not currently have any make instructions.
+For the ecad-labs simulator, execute the following commands:
+```sh
+$ cd ecad-labs/clarvi
+$ vsim -c -do fib_test.do > run.log
+$ grep "f0000000" run.log #This will find the magic output store.
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # riscv-lite
 Versions of RISC-V that only execute the fib() function.
+
+## Directory structure:
+- fib: contains the fibonacci code
+- csim: simulator written in C
+- jsim: simulator written in Java
+- vsim: simulator written in SystemVerilog (currently does not support memory operations).
+- ecad-labs: simulator built on SystemVerilog with a more sophisticated core.
+
+## Build instructions:
+For the java simulator execute the following commands:
+```sh
+$ cd jsim
+$ make
+$ make run
+```
+
+For the C simulator execute the following commands:
+```sh
+$ cd csim
+$ make
+$ ./csim
+```
+
+The vsim simulator does not currently support memory operations.
+
+The ecad-labs simulator does not currently have any make instructions.

--- a/csim/csim.h
+++ b/csim/csim.h
@@ -52,9 +52,9 @@ typedef enum {Rtype=0,Itype=1,Stype=2,Btype=3,Utype=4,Jtype=5,Udef=6} instClass;
 
 static const char *instClassStr[] = {"Rtype","Itype","Stype","Btype","Utype","Jtype","Udef"};
 
-typedef enum {UDEF, ADD, ADDI, AUIPC, BLT, J, JAL, JALR, LW, MV, SW} inst_t;
+typedef enum {UDEF, ADD, ADDI, AUIPC, BLT, J, JAL, JALR, LUI, LW, MV, SW} inst_t;
 
-static const char *instStr[] = {"UDEF", "ADD", "ADDI", "AUIPC", "BLTU", "J", "JAL", "JALR", "LW", "MV", "SW"};
+static const char *instStr[] = {"UDEF", "ADD", "ADDI", "AUIPC", "BLTU", "J", "JAL", "JALR", "LUI", "LW", "MV", "SW"};
 
 
 typedef uint8_t   reg_t;

--- a/ecad-labs/clarvi/bram.sv
+++ b/ecad-labs/clarvi/bram.sv
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 `timescale 1ns/10ps
 
 module dual_port_bram #(
-    parameter INIT_FILE = "mem.hex",
+    parameter INIT_FILE = "../../fib/build/mem.txt",
     parameter ADDRESS_WIDTH = 12,
     parameter BYTE_WIDTH = 8,
     parameter BYTES_PER_WORD = 4

--- a/ecad-labs/clarvi/fib_test.do
+++ b/ecad-labs/clarvi/fib_test.do
@@ -29,6 +29,8 @@ vlog clarvi_avalon.sv
 vlog bram.sv
 vlog clarvi_sim.sv
 
+vsim work.clarvi_sim -t ns -voptargs=+acc=npr
+
 add wave -position insertpoint \
 sim:/clarvi_sim/clock
 

--- a/ecad-labs/clarvi/fib_test.do
+++ b/ecad-labs/clarvi/fib_test.do
@@ -1,0 +1,36 @@
+# Copyright (c) 2016, Robert Eady
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+vlib work
+
+vlog clarvi.sv +define+TRACE
+
+vlog clarvi_avalon.sv
+vlog bram.sv
+vlog clarvi_sim.sv
+
+add wave -position insertpoint \
+sim:/clarvi_sim/clock
+
+run 20us
+exit


### PR DESCRIPTION
CSIM: added LUI instruction and magic output device
Clarvi: added fib_test.do to run fibonacci and made fib default in bram.sv
Readme: added build instructions for all 4 platforms.